### PR TITLE
feat: add segment properties endpoint and links

### DIFF
--- a/materializationengine/blueprints/client/api2.py
+++ b/materializationengine/blueprints/client/api2.py
@@ -9,6 +9,7 @@ from middle_auth_client import (
     auth_requires_permission,
 )
 import pandas as pd
+import numpy as np
 import datetime
 from typing import List
 import werkzeug
@@ -64,7 +65,7 @@ authorizations = {
 }
 
 client_bp = Namespace(
-    "Materialization Client",
+    "Materialization Client2",
     authorizations=authorizations,
     description="Materialization Client",
 )
@@ -1017,6 +1018,7 @@ class MatTableSegmentInfo(Resource):
 
             tags = []
             numerical = []
+            bool_tags = []
             for col in df.columns:
                 if col.endswith("_supervoxel_id"):
                     continue
@@ -1047,6 +1049,9 @@ class MatTableSegmentInfo(Resource):
                 if df[col].dtype == "object":
                     tags.append(col)
                     print(f"tag col: {col}")
+                elif df[col].dtype == bool:
+                    bool_tags.append(col)
+                    print(f"bool tag col: {col}")
                 else:
                     # if the column is all nan's skip it
                     if df[col].isnull().all():
@@ -1057,6 +1062,7 @@ class MatTableSegmentInfo(Resource):
                 df,
                 id_col=root_id_col,
                 tag_value_cols=tags,
+                tag_bool_cols=bool_tags,
                 number_cols=numerical,
                 label_col="id",
             )

--- a/materializationengine/blueprints/client/api2.py
+++ b/materializationengine/blueprints/client/api2.py
@@ -1076,6 +1076,24 @@ class MatTableSegmentInfo(Resource):
                     bool_tags,
                     numerical,
                 )
+            # Look across the tag columns and make sure that there are no
+            # duplicate string values across distinct columns
+            unique_vals = {}
+            for tag in tags:
+                unique_vals[tag] = df[tag].unique()
+            # find all the duplicate values across columns
+            vals, counts = np.unique(
+                np.concatenate([v for v in unique_vals.values()]), return_counts=True
+            )
+            duplicates = vals[counts > 1]
+
+            # iterate through the tags and replace any duplicate
+            # values in the dataframe with a unique value,
+            # based on preprending the column name
+            for tag in tags:
+                for dup in duplicates:
+                    if dup in unique_vals[tag]:
+                        df[tag] = df[tag].replace(dup, f"{tag}:{dup}")
 
             seg_prop = nglui.segmentprops.SegmentProperties.from_dataframe(
                 df,

--- a/materializationengine/blueprints/client/common.py
+++ b/materializationengine/blueprints/client/common.py
@@ -288,7 +288,7 @@ def handle_simple_query(
     )
 
 
-def handle_complex_query(
+def generate_complex_query_dataframe(
     datastack_name,
     version,
     target_datastack,
@@ -446,6 +446,27 @@ def handle_complex_query(
     if len(df) == limit:
         warnings.append(f'201 - "Limited query to {limit} rows')
 
+    return df, warnings, column_names
+
+
+def handle_complex_query(
+    datastack_name,
+    version,
+    target_datastack,
+    target_version,
+    args,
+    data,
+    convert_desired_resolution=False,
+):
+    df, warnings, column_names = generate_complex_query_dataframe(
+        datastack_name,
+        version,
+        target_datastack,
+        target_version,
+        args,
+        data,
+        convert_desired_resolution=convert_desired_resolution,
+    )
     return create_query_response(
         df,
         warnings=warnings,

--- a/materializationengine/blueprints/client/common.py
+++ b/materializationengine/blueprints/client/common.py
@@ -184,7 +184,7 @@ def validate_table_args(tables, datastack_name, version):
             )
 
 
-def handle_simple_query(
+def generate_simple_query_dataframe(
     datastack_name,
     version,
     table_name,
@@ -277,6 +277,30 @@ def handle_simple_query(
     if len(df) == limit:
         warnings.append(f'201 - "Limited query to {limit} rows')
     warnings = update_notice_text_warnings(ann_md, warnings, table_name)
+
+    return df, warnings, column_names
+
+
+def handle_simple_query(
+    datastack_name,
+    version,
+    table_name,
+    target_datastack,
+    target_version,
+    args,
+    data,
+    convert_desired_resolution=False,
+):
+    df, warnings, column_names = generate_simple_query_dataframe(
+        datastack_name,
+        version,
+        table_name,
+        target_datastack,
+        target_version,
+        args,
+        data,
+        convert_desired_resolution=convert_desired_resolution,
+    )
     return create_query_response(
         df,
         warnings=warnings,

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ flask_cors
 numpy>=1.20
 emannotationschemas>=5.11.0
 dynamicannotationdb>=5.7.2
-nglui>=2.10.1
+nglui>=3.2.1
 Flask-Limiter[redis]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -314,7 +314,7 @@ networkx==2.5
     #   cloud-volume
 neuroglancer==2.39.2
     # via nglui
-nglui==3.2.1
+nglui==3.3.1
     # via -r requirements.in
 numexpr==2.10.1
     # via tables

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,13 @@ amqp==5.0.9
     # via kombu
 aniso8601==9.0.1
     # via flask-restx
+appnope==0.1.4
+    # via ipython
 async-timeout==4.0.2
     # via aiohttp
-attrs==21.4.0
+atomicwrites==1.4.1
+    # via neuroglancer
+attrs==23.2.0
     # via
     #   aiohttp
     #   caveclient
@@ -28,6 +32,8 @@ backcall==0.2.0
     # via ipython
 billiard==3.6.4.0
     # via celery
+blosc2==2.5.1
+    # via tables
 boto3==1.21.3
     # via
     #   cloud-files
@@ -46,8 +52,10 @@ cachetools==5.0.0
     #   caveclient
     #   google-auth
     #   middle-auth-client
-caveclient==5.1.0
-    # via -r requirements.in
+caveclient==5.22.0
+    # via
+    #   -r requirements.in
+    #   nglui
 celery==5.2.5
     # via -r requirements.in
 certifi==2021.10.8
@@ -121,6 +129,8 @@ emannotationschemas==5.17.0
     # via
     #   -r requirements.in
     #   dynamicannotationdb
+fasteners==0.19
+    # via google-apitools
 fastremap==1.12.2
     # via cloud-volume
 flask==2.0.2
@@ -138,7 +148,9 @@ flask-accepts==0.18.4
 flask-admin==1.6.0
     # via -r requirements.in
 flask-cors==3.0.10
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   emannotationschemas
 flask-limiter[redis]==3.3.0
     # via -r requirements.in
 flask-marshmallow==0.14.0
@@ -155,7 +167,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2022.1.0
+fsspec==2022.01.0
     # via gcsfs
 furl==2.1.3
     # via middle-auth-client
@@ -175,6 +187,8 @@ google-api-core==2.4.0
     # via
     #   google-cloud-core
     #   google-cloud-storage
+google-apitools==0.5.32
+    # via neuroglancer
 google-auth==2.6.0
     # via
     #   cloud-files
@@ -184,6 +198,7 @@ google-auth==2.6.0
     #   google-auth-oauthlib
     #   google-cloud-core
     #   google-cloud-storage
+    #   neuroglancer
 google-auth-oauthlib==0.4.6
     # via gcsfs
 google-cloud-core==2.2.2
@@ -206,6 +221,10 @@ googleapis-common-protos==1.54.0
     # via google-api-core
 greenlet==1.1.2
     # via gevent
+httplib2==0.22.0
+    # via
+    #   google-apitools
+    #   oauth2client
 idna==3.3
     # via
     #   requests
@@ -246,7 +265,7 @@ jsonschema==3.2.0
     #   python-jsonschema-objects
 kombu==5.2.3
     # via celery
-limits[redis]==3.3.1
+limits==3.3.1
     # via flask-limiter
 mako==1.1.6
     # via alembic
@@ -277,6 +296,8 @@ mdurl==0.1.2
     # via markdown-it-py
 middle-auth-client==3.11.0
     # via -r requirements.in
+msgpack==1.0.8
+    # via blosc2
 multidict==6.0.2
     # via
     #   aiohttp
@@ -285,15 +306,22 @@ multiprocess==0.70.12.2
     # via pathos
 multiwrapper==0.1.1
     # via -r requirements.in
+ndindex==1.8
+    # via blosc2
 networkx==2.5
     # via
     #   caveclient
     #   cloud-volume
-nglui==2.10.1
+neuroglancer==2.39.2
+    # via nglui
+nglui==3.2.1
     # via -r requirements.in
-numpy==1.21.5
+numexpr==2.10.1
+    # via tables
+numpy==1.26.4
     # via
     #   -r requirements.in
+    #   blosc2
     #   caveclient
     #   cloud-volume
     #   compressed-segmentation
@@ -302,12 +330,17 @@ numpy==1.21.5
     #   fastremap
     #   fpzip
     #   multiwrapper
+    #   neuroglancer
     #   nglui
+    #   numexpr
     #   pandas
     #   pyarrow
     #   pyspng-seunglab
     #   shapely
     #   simplejpeg
+    #   tables
+oauth2client==4.1.3
+    # via google-apitools
 oauthlib==3.2.0
     # via requests-oauthlib
 ordered-set==4.1.0
@@ -322,6 +355,7 @@ packaging==21.3
     #   limits
     #   pytest
     #   redis
+    #   tables
 pandas==1.3.5
     # via
     #   -r requirements.in
@@ -341,6 +375,7 @@ pillow==9.0.1
     # via
     #   -r requirements.in
     #   cloud-volume
+    #   neuroglancer
 pluggy==1.0.0
     # via pytest
 posix-ipc==1.0.5
@@ -370,16 +405,23 @@ ptyprocess==0.7.0
     # via pexpect
 py==1.11.0
     # via pytest
+py-cpuinfo==9.0.0
+    # via
+    #   blosc2
+    #   tables
 pyarrow==3.0.0
     # via
     #   -r requirements.in
     #   caveclient
 pyasn1==0.4.8
     # via
+    #   oauth2client
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.2.8
-    # via google-auth
+    # via
+    #   google-auth
+    #   oauth2client
 pycparser==2.21
     # via cffi
 pygments==2.14.0
@@ -389,7 +431,9 @@ pygments==2.14.0
 pyopenssl==22.0.0
     # via urllib3
 pyparsing==3.0.7
-    # via packaging
+    # via
+    #   httplib2
+    #   packaging
 pyrsistent==0.18.1
     # via jsonschema
 pysimdjson==4.0.3
@@ -414,9 +458,7 @@ pytz==2021.3
     #   flask-restx
     #   pandas
 redis==4.1.4
-    # via
-    #   limits
-    #   middle-auth-client
+    # via middle-auth-client
 requests==2.26.0
     # via
     #   -r requirements.in
@@ -427,6 +469,8 @@ requests==2.26.0
     #   google-api-core
     #   google-cloud-storage
     #   middle-auth-client
+    #   neuroglancer
+    #   nglui
     #   requests-oauthlib
 requests-oauthlib==1.3.1
     # via google-auth-oauthlib
@@ -436,6 +480,7 @@ rsa==4.8
     # via
     #   cloud-files
     #   google-auth
+    #   oauth2client
 s3transfer==0.5.1
     # via boto3
 shapely==2.0.3
@@ -453,9 +498,11 @@ six==1.16.0
     #   flask-marshmallow
     #   flask-restx
     #   furl
+    #   google-apitools
     #   google-auth
     #   jsonschema
     #   nglui
+    #   oauth2client
     #   orderedmultidict
     #   ppft
     #   python-dateutil
@@ -469,12 +516,16 @@ sqlalchemy==1.3.24
     #   flask-sqlalchemy
     #   geoalchemy2
     #   marshmallow-sqlalchemy
+tables==3.9.2
+    # via nglui
 tenacity==8.0.1
     # via
     #   cloud-files
     #   cloud-volume
 tomli==2.0.1
     # via pytest
+tornado==6.4.1
+    # via neuroglancer
 tqdm==4.62.3
     # via
     #   cloud-files


### PR DESCRIPTION
this adds a new endpoint for getting segment properties based on a cave table
```
materialize/api/v3/datastack/[DATASTACK_NAME]/version/[VERSION]/table/[TABLE_NAME]/info
```

this can then be directly added to neuroglancer as a source with the source URL

```
precomputed://middleauth+https://[SERVER_LOCATION]/{seginfo_url}/materialize/api/v3/datastack/[DATASTACK_NAME]/version/[VERSION]/table/[TABLE_NAME]
```

a neuroglancer link has been added to the view for each datastack version that then lets users go to neuroglancer with an image layer and segmentation layer setup for the datastack with this segment info added and enabled.

