### PR TITLE
Configurable materialization cron

### DIFF
--- a/materializationengine/celery_worker.py
+++ b/materializationengine/celery_worker.py
@@ -151,7 +151,7 @@ def setup_periodic_tasks(sender, **kwargs):
 
         elif task_name == "run_periodic_materialization":
             # If `days_to_expire` is not provided, calculate it dynamically #TODO handle this better
-            if datastack_params["days_"] == 30:
+            if datastack_params.get("days_to_expire") == 30:
                 datastack_params["days_to_expire"] = days_till_next_month(
                     datetime.datetime.now(datetime.timezone.utc)
                 )

--- a/materializationengine/config.py
+++ b/materializationengine/config.py
@@ -59,6 +59,13 @@ class BaseConfig:
             "minute": 10,
             "hour": 8,
             "day_of_week": [0, 2, 4, 6],
+            "task": "run_daily_periodic_materialization",
+        },        
+        {
+            "name": "Materialize Specific Database Daily",
+            "minute": 10,
+            "hour": 8,
+            "day_of_week": [0, 2, 4, 6],
             "task": "run_periodic_materialization",
             "datastack_params": {
                 "days_to_expire": 2,
@@ -86,7 +93,7 @@ class BaseConfig:
             "day_of_week": [1, 5],
             "task": "run_periodic_materialization",
             "datastack_params": {
-                "days_to_expire": 2,
+                "days_to_expire": 7,
             }
         },
         {

--- a/materializationengine/config.py
+++ b/materializationengine/config.py
@@ -59,7 +59,12 @@ class BaseConfig:
             "minute": 10,
             "hour": 8,
             "day_of_week": [0, 2, 4, 6],
-            "task": "run_daily_periodic_materialization",
+            "task": "run_periodic_materialization",
+            "datastack_params": {
+                "days_to_expire": 2,
+                "merge_tables": False,
+                "datastack": "minnie65_phase3_v1",
+            },
         },
         {
             "name": "Materialized Database Daily (2 Days) (Wednesdays)",
@@ -67,14 +72,22 @@ class BaseConfig:
             "hour": 8,
             "day_of_week": 3,
             "day_of_month": "8-14,22-31",
-            "task": "run_daily_periodic_materialization",
+            "task": "run_periodic_materialization",
+            "datastack_params": {
+                "days_to_expire": 2,
+                "merge_tables": False,
+                "datastack": "minnie65_phase3_v1",
+            },
         },
         {
             "name": "Materialized Database Weekly (7 Days)",
             "minute": 10,
             "hour": 8,
             "day_of_week": [1, 5],
-            "task": "run_weekly_periodic_materialization",
+            "task": "run_periodic_materialization",
+            "datastack_params": {
+                "days_to_expire": 2,
+            }
         },
         {
             "name": "Long Term Support Materialized Database (30 days)",
@@ -82,13 +95,14 @@ class BaseConfig:
             "hour": 8,
             "day_of_week": 3,
             "day_of_month": "1-7,15-21",
-            "task": "run_lts_periodic_materialization",
+            "task": "run_periodic_materialization",
         },
         {
             "name": "Remove Expired Databases (Midnight)",
             "minute": 0,
             "hour": 8,
             "task": "remove_expired_databases",
+            "datastack_params": {"delete_threshold": 5},
         },
         {
             "name": "Update Live Database",

--- a/materializationengine/errors.py
+++ b/materializationengine/errors.py
@@ -53,3 +53,8 @@ class TaskNotFound(KeyError):
 
     def __str__(self):
         return f"{self.message}"
+
+
+class ConfigurationError(Exception):
+    """Custom exception for configuration errors."""
+    pass

--- a/materializationengine/schemas.py
+++ b/materializationengine/schemas.py
@@ -45,6 +45,12 @@ class CronField(fields.Field):
             raise ValidationError("Field should be str, int or list")
 
 
+class CeleryDatastackSchema(Schema):
+    days_to_expire = fields.Int(required=False)
+    merge_tables = fields.Bool(required=False)
+    datastack = fields.Str(required=False)
+    delete_threshold = fields.Int(required=False)
+
 class CeleryBeatSchema(Schema):
     name = fields.Str(required=True)
     minute = CronField(default="*")
@@ -53,3 +59,4 @@ class CeleryBeatSchema(Schema):
     day_of_month = CronField(default="*")
     month_of_year = CronField(default="*")
     task = fields.Str(required=True)
+    datastack_params = CeleryDatastackSchema(required=False)

--- a/materializationengine/schemas.py
+++ b/materializationengine/schemas.py
@@ -70,24 +70,21 @@ class TaskParamsSchema(Schema):
 
 class CeleryBeatSchema(Schema):
     name = fields.Str(required=True, metadata={"description": "Name of the task"})
-    minute = fields.Str(
+    minute = CronField(
         default="*", metadata={"description": "Minute field for cron schedule"}
     )
-    hour = fields.Str(
+    hour = CronField(
         default="*", metadata={"description": "Hour field for cron schedule"}
     )
-    day_of_week = fields.Str(
-        required=False,
+    day_of_week = CronField(
         default="*",
         metadata={"description": "Day of week for cron schedule"},
     )
-    day_of_month = fields.Str(
-        required=False,
+    day_of_month = CronField(
         default="*",
         metadata={"description": "Day of month for cron schedule"},
     )
-    month_of_year = fields.Str(
-        required=False,
+    month_of_year = CronField(
         default="*",
         metadata={"description": "Month of year for cron schedule"},
     )

--- a/materializationengine/schemas.py
+++ b/materializationengine/schemas.py
@@ -59,4 +59,4 @@ class CeleryBeatSchema(Schema):
     day_of_month = CronField(default="*")
     month_of_year = CronField(default="*")
     task = fields.Str(required=True)
-    datastack_params = CeleryDatastackSchema(required=False)
+    datastack_params = fields.Nested(CeleryDatastackSchema, required=False)

--- a/materializationengine/workflows/periodic_materialization.py
+++ b/materializationengine/workflows/periodic_materialization.py
@@ -17,13 +17,36 @@ from materializationengine.workflows.complete_workflow import run_complete_workf
 celery_logger = get_task_logger(__name__)
 
 
-def _get_datastacks() -> List:
-    raise NotImplementedError
+def process_datastack(datastack, days_to_expire, merge_tables):
+    celery_logger.info(f"Start periodic materialization job for {datastack}")
+
+    datastack_info = get_datastack_info(datastack)
+    aligned_volume = datastack_info["aligned_volume"]["name"]
+
+    session = sqlalchemy_cache.get(aligned_volume)
+    max_databases = get_config_param("MAX_DATABASES")
+
+    valid_databases = (
+        session.query(AnalysisVersion)
+        .filter(AnalysisVersion.valid == True)
+        .filter(AnalysisVersion.datastack == datastack)
+        .filter(AnalysisVersion.parent_version != None)
+        .order_by(AnalysisVersion.time_stamp)
+        .count()
+    )
+    if valid_databases >= max_databases:
+        return f"Number of valid materialized databases is {valid_databases}, threshold is set to: {max_databases}"
+    datastack_info["database_expires"] = True
+    task = run_complete_workflow.s(
+        datastack_info, days_to_expire=days_to_expire, merge_tables=merge_tables
+    )
+    task.apply_async(kwargs={"Datastack": datastack})
+    return True
 
 
 @celery.task(name="workflow:run_periodic_materialization")
 def run_periodic_materialization(
-    days_to_expire: int = None, merge_tables: bool = True
+    days_to_expire: int = None, merge_tables: bool = True, datastack: str = None
 ) -> None:
     """
     Run complete materialization workflow. Steps are as follows:
@@ -38,37 +61,19 @@ def run_periodic_materialization(
     )
     if is_update_roots_running:
         return "Update Roots Workflow is running, delaying materialization until update roots is complete."
-    try:
-        datastacks = json.loads(os.environ["DATASTACKS"])
-    except:
-        datastacks = get_config_param("DATASTACKS")
+
+    if datastack:
+        datastacks = [datastack]
+
+    else:
+        try:
+            datastacks = json.loads(os.environ["DATASTACKS"])
+        except Exception as e:
+            datastacks = get_config_param("DATASTACKS")
 
     for datastack in datastacks:
         try:
-            celery_logger.info(f"Start periodic materialization job for {datastack}")
-
-            datastack_info = get_datastack_info(datastack)
-            aligned_volume = datastack_info["aligned_volume"]["name"]
-
-            session = sqlalchemy_cache.get(aligned_volume)
-            max_databases = get_config_param("MAX_DATABASES")
-
-            valid_databases = (
-                session.query(AnalysisVersion)
-                .filter(AnalysisVersion.valid == True)
-                .filter(AnalysisVersion.datastack == datastack)
-                .filter(AnalysisVersion.parent_version != None)
-                .order_by(AnalysisVersion.time_stamp)
-                .count()
-            )
-            if valid_databases >= max_databases:
-                return f"Number of valid materialized databases is {valid_databases}, threshold is set to: {max_databases}"
-            datastack_info["database_expires"] = True
-            task = run_complete_workflow.s(
-                datastack_info, days_to_expire=days_to_expire, merge_tables=merge_tables
-            )
-            task.apply_async(kwargs={"Datastack": datastack})
+            is_running = process_datastack(datastack, days_to_expire, merge_tables)
         except Exception as e:
             celery_logger.error(e)
             raise e
-    return True

--- a/materializationengine/workflows/update_database_workflow.py
+++ b/materializationengine/workflows/update_database_workflow.py
@@ -26,17 +26,20 @@ celery_logger = get_task_logger(__name__)
 
 
 @celery.task(name="workflow:run_periodic_database_update")
-def run_periodic_database_update() -> None:
+def run_periodic_database_update(datastack: str = None) -> None:
     """
     Run update database workflow. Steps are as follows:
     1. Find missing segmentation data in a given datastack and lookup.
     2. Update expired root ids
 
     """
-    try:
-        datastacks = json.loads(os.environ["DATASTACKS"])
-    except:
-        datastacks = get_config_param("DATASTACKS")
+    if datastack:
+        datastacks = [datastack]
+    else:
+        try:
+            datastacks = json.loads(os.environ["DATASTACKS"])
+        except Exception:
+            datastacks = get_config_param("DATASTACKS")
 
     for datastack in datastacks:
         try:


### PR DESCRIPTION
Add the ability to pass optional args to the celery beat scheduler. This can allow for users to separate when they want to run materialization if using multiple datastacks. 